### PR TITLE
close #28. add url bi-directional binding on search component search term

### DIFF
--- a/app/app-routing.module.ts
+++ b/app/app-routing.module.ts
@@ -1,0 +1,27 @@
+import { NgModule }              from '@angular/core';
+import { RouterModule, Routes }  from '@angular/router';
+
+import { SearchComponent } from './search/search.component';
+
+const appRoutes = [
+  { path: 'search', component: SearchComponent },
+  { path: '',
+    redirectTo: '/search',
+    pathMatch: 'full'
+  }
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forRoot(
+      appRoutes, { 
+        enableTracing: true, // debugging porpuse
+        useHash: true
+      }     
+    )
+  ],
+  exports: [
+    RouterModule
+  ]
+})
+export class AppRoutingModule { }

--- a/app/app.component.html
+++ b/app/app.component.html
@@ -1,5 +1,5 @@
 <budgetkey-container>
     <div class="container-fluid">
-        <budget-search ></budget-search>
+      <router-outlet></router-outlet>
     </div>
 </budgetkey-container>

--- a/app/app.component.spec.ts
+++ b/app/app.component.spec.ts
@@ -6,6 +6,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppComponent }  from './app.component';
 import { HttpModule } from '@angular/http';
+import { AppRoutingModule } from './app-routing.module';
 import { SearchService } from './_service/search.service';
 import { SearchComponent } from './search/search.component';
 
@@ -28,7 +29,8 @@ describe('AppComponent', function () {
     return TestBed.configureTestingModule({
       imports: [
         HttpModule,
-        BudgetKeyCommonModule
+        BudgetKeyCommonModule,
+        AppRoutingModule,
       ],
       declarations: [
         AppComponent,

--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -18,11 +18,14 @@ import { SearchResultEntitiesComponent } from './search_result/search_result.com
 
 import { Highlighter } from './highlighter/search.highlighter';
 
+import { AppRoutingModule } from './app-routing.module';
+
 @NgModule({
   imports:      [
     BrowserModule,
     HttpModule,
-    BudgetKeyCommonModule
+    BudgetKeyCommonModule,
+    AppRoutingModule
   ],
   declarations: [
     AppComponent,

--- a/app/search/search.component.html
+++ b/app/search/search.component.html
@@ -7,7 +7,9 @@
                class="form-control"
                type="text"
                placeholder="חפשו במפתח"
-               (keyup)="search(searchBox.value)"/>
+               (keyup)="search(searchBox.value)"
+               [value]="term"
+               />
         <span class="input-group-addon">
           <i *ngIf="!isSearching" [ngClass]="['glyphicon', 'glyphicon-search', term ? 'search-icon' : '']" (click)="term ? search(term) : undefined"></i>
           <img *ngIf="isSearching" class="search-loader" src="assets/img/loader.svg" />

--- a/app/search/search.component.ts
+++ b/app/search/search.component.ts
@@ -7,7 +7,8 @@ import { Subject }           from 'rxjs/Subject';
 import { BehaviorSubject }   from 'rxjs/BehaviorSubject';
 import { SearchService }     from '../_service/search.service';
 import { SearchResults, DocResultEntry, SearchResultsCounter} from '../_model/SearchResults';
-
+import { Router, ActivatedRoute, Params } from '@angular/router';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'budget-search',
@@ -19,7 +20,7 @@ export class SearchComponent implements OnInit {
 
   private searchTerms: Subject<string>;
   private searchResults: Observable<SearchResults>;
-  private term: string;
+  private term: string = '';
   private allDocs: BehaviorSubject<DocResultEntry[]>;
   private allResults: any;
   private resultTotal: number;
@@ -34,11 +35,17 @@ export class SearchComponent implements OnInit {
   private headerBottomBorder: boolean;
   private isSearching: boolean;
   private isErrorInLastSearch: boolean;
+  private searchTerm: string;
 
   @ViewChild('searchBody')
   private searchBodyEl: ElementRef;
 
-  constructor(private searchService: SearchService) {}
+  constructor(
+    private searchService: SearchService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private location: Location
+  ) {}
 
   ngOnInit() {
     this.searchTerms = new Subject<string>();
@@ -62,7 +69,14 @@ export class SearchComponent implements OnInit {
     this.searchResults = this.searchTerms // open a stream
       .debounceTime(300)        // wait for 300ms pause in events
       // .distinctUntilChanged()   // ignore if next search term is same as previous
-      .switchMap(() => this.doRequest())
+      .switchMap(() => {
+        if (this.term) {
+          this.location.go(`/search?term=${this.term}`);
+        } else {
+          this.location.go(`/search`);
+        }
+        return this.doRequest();
+      })
       .catch(error => {
         this.isSearching = false;
         this.isErrorInLastSearch = true;
@@ -73,7 +87,14 @@ export class SearchComponent implements OnInit {
       this.isSearching = false;
       this.processResults(results);
     });
-    this.search('חינוך'); // a default search query, to get things started..
+
+    this.route.queryParams
+      .subscribe((params: Params) => {
+        if (params.term) {
+          this.search(params.term);
+        }
+        return null;
+      });
   }
 
   /**

--- a/app/search/search.component.ts
+++ b/app/search/search.component.ts
@@ -35,7 +35,6 @@ export class SearchComponent implements OnInit {
   private headerBottomBorder: boolean;
   private isSearching: boolean;
   private isErrorInLastSearch: boolean;
-  private searchTerm: string;
 
   @ViewChild('searchBody')
   private searchBodyEl: ElementRef;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <title>מפתח התקציב - חיפוש</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <base href="/">
   </head>
 
   <body>


### PR DESCRIPTION
Main development:
- insert angular router usage. Configured in app.module via sub module off app routes.
- search component is loaded via router outlet.
- 'in': search component on start - register to router params observer. each "term" param change, activate search. 
- 'out': search component on search - update browser address bar via 'location.go' semi hardcoded path. Does not reactivate the Router and component again. Currently no official way to do this with the Router service. 
- reflect term change in user input via one direction bind on value. 
