### PR TITLE
update #28. remove <base href> tag from usage

### DIFF
--- a/app/app-routing.module.ts
+++ b/app/app-routing.module.ts
@@ -15,7 +15,6 @@ const appRoutes = [
   imports: [
     RouterModule.forRoot(
       appRoutes, { 
-        enableTracing: true, // debugging porpuse
         useHash: true
       }     
     )

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <title>מפתח התקציב - חיפוש</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <base href="/">
   </head>
 
   <body>


### PR DESCRIPTION
Update on #28 issue. We use the old location strategy - hashLocationStrategy - that does not need <base href> therefor removing it. This also solve the issue of deploying on non root url. 