### PR TITLE
add support for modifying the generic item page url via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN apk add --update git
 
 ENV NODE_ENV=production
 
+ARG BUDGETKEY_GENERIC_ITEM_BASE_URL
+
 RUN cd /app/ && \
     npm install --dev && \
     npm run dist

--- a/app/_config/config.ts
+++ b/app/_config/config.ts
@@ -9,3 +9,12 @@ export const URL = REMOTE_URL;
 export let Colors = {
   bgColor: '#ccc'
 };
+
+declare const process: any;
+
+export let GENERIC_ITEM_BASE_URL: any;
+if (process.env.BUDGETKEY_GENERIC_ITEM_BASE_URL) {
+  GENERIC_ITEM_BASE_URL = process.env.BUDGETKEY_GENERIC_ITEM_BASE_URL;
+} else {
+  GENERIC_ITEM_BASE_URL = 'https://next.obudget.org/i/';
+}

--- a/app/search_result/search_result.component.html
+++ b/app/search_result/search_result.component.html
@@ -11,7 +11,7 @@
       </div>
       <div class="row title-part">
           <div class="col-md-8 title-right-part">
-              <a href="http://next.obudget.org/i/{{get('doc_id')}}">
+              <a href="{{genericItemBaseUrl}}{{get('doc_id')}}">
                   <div class="title-bit">
                       <span class="pretitle" *ngIf="parameters.secondaryNameField" innerHTML="{{get(parameters.secondaryNameField)}}"></span>
                       <span class="title" innerHTML="{{get(parameters.mainNameField)}}"></span>

--- a/app/search_result/search_result.component.ts
+++ b/app/search_result/search_result.component.ts
@@ -4,6 +4,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { DocResultEntry } from '../_model/SearchResults';
 import { KIND_PARAMETERS } from './kind_parameters';
+import { GENERIC_ITEM_BASE_URL } from '../_config/config';
 let _ = require('lodash');
 
 
@@ -16,6 +17,7 @@ export class SearchResultComponent implements OnInit {
   @Input() item: DocResultEntry;
   @Input() kind: string;
   parameters: any;
+  genericItemBaseUrl: any = GENERIC_ITEM_BASE_URL;
 
   constructor() { }
   ngOnInit() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,10 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var plugins = [
   new webpack.DefinePlugin({
-    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    'process.env': {
+      'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'BUDGETKEY_GENERIC_ITEM_BASE_URL': JSON.stringify(process.env.BUDGETKEY_GENERIC_ITEM_BASE_URL)
+    }
   }),
   new HtmlWebpackPlugin({
     template: 'index.html'


### PR DESCRIPTION
Example usage: (assuming you have a generic item server running on port 8080)

```
BUDGETKEY_GENERIC_ITEM_BASE_URL=http://localhost:8080/ npm run dist-serve
```

For Docker it's implemented as a build arg:

```
docker build --build-arg BUDGETKEY_GENERIC_ITEM_BASE_URL=http://localhost:8080/ -t budgetkey-app-search:itemurl8080 .
docker run -it -p 8000:8000 budgetkey-app-search:itemurl8080
```
